### PR TITLE
Feature/journalctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,16 @@ g-systemctl is a terminal user interface (TUI) for managing system services on L
 - Start/stop services with a single keypress
 - Cross-platform support (Linux via systemctl, macOS via launchctl)
 - Keyboard-driven navigation
+- Mouse support (scroll to navigate, click to select)
+- Initial filter via command line argument (`-f` / `--filter`)
+- View service logs via journalctl (requires tmux)
 
 ## Prerequisites
 
 - CMake 3.14+
 - C++17 compatible compiler (GCC 7+, Clang 5+)
 - Linux with systemd or macOS
+- tmux (optional, required for viewing service logs)
 
 ## Installation
 
@@ -63,16 +67,27 @@ sudo g-systemctl
 | `Down` / `j` | Move selection down |
 | `Enter` | Toggle selected service (start/stop) |
 | `r` | Refresh service list |
+| `l` | Open logs for selected service (tmux only) |
 | `?` | Show/hide help |
 | `q` / `Esc` | Quit |
 | Type | Filter services by name |
 | `Backspace` | Delete filter character |
 
+### Mouse Support
+
+| Action | Effect |
+|--------|--------|
+| Scroll up/down | Navigate the service list |
+| Left click | Select a service |
+
 ## Command Line Options
 
 ```bash
-g-systemctl --help     # Show help
-g-systemctl --version  # Show version
+g-systemctl --help              # Show help
+g-systemctl --version           # Show version
+g-systemctl --system            # Show system services instead of user services
+g-systemctl -f <text>           # Start with an initial filter
+g-systemctl --filter <text>     # Start with an initial filter
 ```
 
 ## Contributing

--- a/include/g-systemctl/core/logging_manager.hpp
+++ b/include/g-systemctl/core/logging_manager.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+#include <memory>
+#include <utility>
+
+namespace gsystemctl {
+
+class CommandExecutor; // forward
+
+class LoggingManager {
+public:
+    virtual ~LoggingManager() = default;
+
+    /// Open a log viewer for the given unit.  When running inside tmux this will
+    /// split the current pane and invoke "journalctl -u <unit> -f".  Returns a
+    /// pair of (success,message) where the message contains human readable error
+    /// information in case of failure.
+    virtual std::pair<bool, std::string> open_logs(const std::string& unit) = 0;
+
+    static std::unique_ptr<LoggingManager> create(
+        std::shared_ptr<CommandExecutor> executor);
+};
+
+} // namespace gsystemctl

--- a/include/g-systemctl/platform/linux_logging_manager.hpp
+++ b/include/g-systemctl/platform/linux_logging_manager.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "g-systemctl/core/logging_manager.hpp"
+#include <memory>
+
+namespace gsystemctl {
+
+class LinuxLoggingManager : public LoggingManager {
+public:
+    explicit LinuxLoggingManager(std::shared_ptr<CommandExecutor> executor);
+
+    std::pair<bool, std::string> open_logs(const std::string& unit) override;
+
+private:
+    std::shared_ptr<CommandExecutor> executor_;
+};
+
+} // namespace gsystemctl

--- a/include/g-systemctl/platform/macos_logging_manager.hpp
+++ b/include/g-systemctl/platform/macos_logging_manager.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "g-systemctl/core/logging_manager.hpp"
+#include <memory>
+
+namespace gsystemctl {
+
+class MacOSLoggingManager : public LoggingManager {
+public:
+    explicit MacOSLoggingManager(std::shared_ptr<CommandExecutor> executor);
+
+    std::pair<bool, std::string> open_logs(const std::string& unit) override;
+
+private:
+    std::shared_ptr<CommandExecutor> executor_;
+};
+
+} // namespace gsystemctl

--- a/include/g-systemctl/ui/app.hpp
+++ b/include/g-systemctl/ui/app.hpp
@@ -32,6 +32,8 @@ namespace gsystemctl::ui
         std::string error_message_;
         bool show_help_ = false;
         std::vector<ftxui::Box> item_boxes_;
+        std::vector<ftxui::Box> toggle_button_boxes_;
+        std::vector<ftxui::Box> log_button_boxes_;
 
         void refresh_services();
         void apply_filter();

--- a/include/g-systemctl/ui/app.hpp
+++ b/include/g-systemctl/ui/app.hpp
@@ -8,36 +8,38 @@
 #include <string>
 #include <vector>
 
-namespace gsystemctl::ui {
+namespace gsystemctl::ui
+{
 
-class App {
-public:
-    App(bool system_mode = false);
-    int run();
+    class App
+    {
+    public:
+        App(bool system_mode = false, const std::string &initial_filter = "");
+        int run();
 
-private:
-    ftxui::ScreenInteractive screen_;
-    std::shared_ptr<ServiceManager> service_manager_;
-    std::unique_ptr<LoggingManager> logging_manager_;
-    bool system_mode_;
+    private:
+        ftxui::ScreenInteractive screen_;
+        std::shared_ptr<ServiceManager> service_manager_;
+        std::unique_ptr<LoggingManager> logging_manager_;
+        bool system_mode_;
 
-    std::vector<ServiceUnit> services_;
-    std::vector<ServiceUnit> filtered_services_;
-    std::string filter_text_;
-    int selected_index_ = 0;
-    std::string status_message_;
-    std::string error_message_;
-    bool show_help_ = false;
+        std::vector<ServiceUnit> services_;
+        std::vector<ServiceUnit> filtered_services_;
+        std::string filter_text_;
+        int selected_index_ = 0;
+        std::string status_message_;
+        std::string error_message_;
+        bool show_help_ = false;
 
-    void refresh_services();
-    void apply_filter();
-    void toggle_selected_service();
-    void open_logs_for_selected_service();
-    ftxui::Component create_main_component();
-    ftxui::Element render();
-    ftxui::Element render_service_list();
-    ftxui::Element render_status_bar();
-    ftxui::Element render_help();
-};
+        void refresh_services();
+        void apply_filter();
+        void toggle_selected_service();
+        void open_logs_for_selected_service();
+        ftxui::Component create_main_component();
+        ftxui::Element render();
+        ftxui::Element render_service_list();
+        ftxui::Element render_status_bar();
+        ftxui::Element render_help();
+    };
 
 } // namespace gsystemctl::ui

--- a/include/g-systemctl/ui/app.hpp
+++ b/include/g-systemctl/ui/app.hpp
@@ -5,6 +5,7 @@
 #include "g-systemctl/core/service.hpp"
 #include <ftxui/component/component.hpp>
 #include <ftxui/component/screen_interactive.hpp>
+#include <ftxui/screen/box.hpp>
 #include <string>
 #include <vector>
 
@@ -30,6 +31,7 @@ namespace gsystemctl::ui
         std::string status_message_;
         std::string error_message_;
         bool show_help_ = false;
+        std::vector<ftxui::Box> item_boxes_;
 
         void refresh_services();
         void apply_filter();

--- a/include/g-systemctl/ui/app.hpp
+++ b/include/g-systemctl/ui/app.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "g-systemctl/core/service_manager.hpp"
+#include "g-systemctl/core/logging_manager.hpp"
 #include "g-systemctl/core/service.hpp"
 #include <ftxui/component/component.hpp>
 #include <ftxui/component/screen_interactive.hpp>
@@ -17,6 +18,7 @@ public:
 private:
     ftxui::ScreenInteractive screen_;
     std::shared_ptr<ServiceManager> service_manager_;
+    std::unique_ptr<LoggingManager> logging_manager_;
     bool system_mode_;
 
     std::vector<ServiceUnit> services_;
@@ -30,6 +32,7 @@ private:
     void refresh_services();
     void apply_filter();
     void toggle_selected_service();
+    void open_logs_for_selected_service();
     ftxui::Component create_main_component();
     ftxui::Element render();
     ftxui::Element render_service_list();

--- a/include/g-systemctl/ui/styles.hpp
+++ b/include/g-systemctl/ui/styles.hpp
@@ -1,19 +1,23 @@
 #pragma once
 
 #include <ftxui/dom/elements.hpp>
+#include <ftxui/screen/box.hpp>
 
-namespace gsystemctl::ui {
+namespace gsystemctl::ui
+{
 
-struct Colors {
-    static ftxui::Color running_fg();
-    static ftxui::Color running_bg();
-    static ftxui::Color stopped_fg();
-    static ftxui::Color stopped_bg();
-    static ftxui::Color selected_bg();
-    static ftxui::Color error_fg();
-};
+    struct Colors
+    {
+        static ftxui::Color running_fg();
+        static ftxui::Color running_bg();
+        static ftxui::Color stopped_fg();
+        static ftxui::Color stopped_bg();
+        static ftxui::Color selected_bg();
+        static ftxui::Color error_fg();
+    };
 
-ftxui::Element service_card(const std::string& name, const std::string& status,
-                            const std::string& description, bool is_running, bool selected);
+    ftxui::Element service_card(const std::string &name, const std::string &status,
+                                const std::string &description, bool is_running, bool selected,
+                                ftxui::Box &toggle_box, ftxui::Box &log_box);
 
 } // namespace gsystemctl::ui

--- a/src/core/logging_manager.cpp
+++ b/src/core/logging_manager.cpp
@@ -1,0 +1,23 @@
+#include "g-systemctl/core/logging_manager.hpp"
+#include "g-systemctl/platform/platform.hpp"
+#include "g-systemctl/platform/linux_logging_manager.hpp"
+#include "g-systemctl/platform/macos_logging_manager.hpp"
+#include <stdexcept>
+
+namespace gsystemctl {
+
+std::unique_ptr<LoggingManager> LoggingManager::create(
+    std::shared_ptr<CommandExecutor> executor) {
+    Platform platform = detect_platform();
+
+    switch (platform) {
+        case Platform::Linux:
+            return std::make_unique<LinuxLoggingManager>(executor);
+        case Platform::MacOS:
+            return std::make_unique<MacOSLoggingManager>(executor);
+        default:
+            throw std::runtime_error("Unsupported platform");
+    }
+}
+
+} // namespace gsystemctl

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,42 +3,58 @@
 #include <iostream>
 #include <cstring>
 
-void print_help() {
+void print_help()
+{
     std::cout << "g-systemctl - Terminal UI for system service management\n\n";
     std::cout << "Usage: g-systemctl [options]\n\n";
     std::cout << "Options:\n";
-    std::cout << "  -h, --help     Show this help message\n";
-    std::cout << "  -v, --version  Show version information\n";
-    std::cout << "  --system       Show system services instead of user services\n\n";
+    std::cout << "  -h, --help              Show this help message\n";
+    std::cout << "  -v, --version           Show version information\n";
+    std::cout << "  --system                Show system services instead of user services\n";
+    std::cout << "  -f, --filter <text>     Set the initial filter text\n\n";
     std::cout << "Note: Run with sudo for full functionality (start/stop services)\n";
 }
 
-void print_version() {
+void print_version()
+{
     std::cout << "g-systemctl version 1.0.0\n";
     std::cout << "Platform: " << gsystemctl::platform_name(gsystemctl::detect_platform()) << "\n";
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[])
+{
     bool system_mode = false;
+    std::string initial_filter;
 
-    for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], "-h") == 0 || std::strcmp(argv[i], "--help") == 0) {
+    for (int i = 1; i < argc; ++i)
+    {
+        if (std::strcmp(argv[i], "-h") == 0 || std::strcmp(argv[i], "--help") == 0)
+        {
             print_help();
             return 0;
         }
-        if (std::strcmp(argv[i], "-v") == 0 || std::strcmp(argv[i], "--version") == 0) {
+        if (std::strcmp(argv[i], "-v") == 0 || std::strcmp(argv[i], "--version") == 0)
+        {
             print_version();
             return 0;
         }
-        if (std::strcmp(argv[i], "--system") == 0) {
+        if (std::strcmp(argv[i], "--system") == 0)
+        {
             system_mode = true;
+        }
+        if ((std::strcmp(argv[i], "-f") == 0 || std::strcmp(argv[i], "--filter") == 0) && i + 1 < argc)
+        {
+            initial_filter = argv[++i];
         }
     }
 
-    try {
-        gsystemctl::ui::App app(system_mode);
+    try
+    {
+        gsystemctl::ui::App app(system_mode, initial_filter);
         return app.run();
-    } catch (const std::exception& e) {
+    }
+    catch (const std::exception &e)
+    {
         std::cerr << "Error: " << e.what() << "\n";
         return 1;
     }

--- a/src/platform/linux_logging_manager.cpp
+++ b/src/platform/linux_logging_manager.cpp
@@ -1,0 +1,40 @@
+#include "g-systemctl/platform/linux_logging_manager.hpp"
+#include "g-systemctl/core/command_executor.hpp"
+#include <cstdlib>
+
+namespace gsystemctl {
+
+LinuxLoggingManager::LinuxLoggingManager(std::shared_ptr<CommandExecutor> executor)
+    : executor_(std::move(executor)) {}
+
+std::pair<bool, std::string> LinuxLoggingManager::open_logs(
+    const std::string& unit) {
+    // Ensure we're inside tmux before trying to split the pane.
+    const char* tmux_env = std::getenv("TMUX");
+    if (!tmux_env) {
+        return {false, "Not running inside a tmux session"};
+    }
+
+    // Build the journalctl command. Quote the unit name to avoid shell issues.
+    std::string command = "tmux split-window -v 'journalctl -u " + unit + " -f'";
+    if (!executor_) {
+        // If we don't have an executor, just run the command directly via system().
+        int rc = std::system(command.c_str());
+        if (rc != 0) {
+            return {false, "failed to execute tmux command"};
+        }
+        return {true, ""};
+    }
+
+    auto result = executor_->execute(command);
+    if (result.exit_code != 0) {
+        std::string msg = "tmux command failed";
+        if (!result.stderr_output.empty()) {
+            msg = result.stderr_output;
+        }
+        return {false, msg};
+    }
+    return {true, ""};
+}
+
+} // namespace gsystemctl

--- a/src/platform/macos_logging_manager.cpp
+++ b/src/platform/macos_logging_manager.cpp
@@ -1,0 +1,13 @@
+#include "g-systemctl/platform/macos_logging_manager.hpp"
+
+namespace gsystemctl {
+
+MacOSLoggingManager::MacOSLoggingManager(std::shared_ptr<CommandExecutor> executor)
+    : executor_(std::move(executor)) {}
+
+std::pair<bool, std::string> MacOSLoggingManager::open_logs(
+    const std::string& /*unit*/) {
+    return {false, "Logging manager is not supported on macOS"};
+}
+
+} // namespace gsystemctl

--- a/src/ui/app.cpp
+++ b/src/ui/app.cpp
@@ -32,7 +32,6 @@ namespace gsystemctl::ui
         {
             services_ = service_manager_->list_services();
             error_message_.clear();
-            status_message_ = "Loaded " + std::to_string(services_.size()) + " services";
             apply_filter();
         }
         catch (const std::exception &e)
@@ -151,12 +150,16 @@ namespace gsystemctl::ui
             if (selected_index_ > 0) {
                 selected_index_--;
             }
+            status_message_.clear();
+            error_message_.clear();
             return true;
         }
         if (event == Event::ArrowDown || event == Event::Character('j')) {
             if (selected_index_ < static_cast<int>(filtered_services_.size()) - 1) {
                 selected_index_++;
             }
+            status_message_.clear();
+            error_message_.clear();
             return true;
         }
         if (event == Event::Return) {
@@ -170,11 +173,15 @@ namespace gsystemctl::ui
         if (event.is_character()) {
             filter_text_ += event.character();
             apply_filter();
+            status_message_.clear();
+            error_message_.clear();
             return true;
         }
         if (event == Event::Backspace && !filter_text_.empty()) {
             filter_text_.pop_back();
             apply_filter();
+            status_message_.clear();
+            error_message_.clear();
             return true;
         }
         return false; });
@@ -197,13 +204,19 @@ namespace gsystemctl::ui
 
         auto title = text(" g-systemctl ") | bold | color(Color::Cyan) | align_right;
 
-        return window(title, vbox({
-                                 filter_line,
-                                 separator(),
-                                 render_service_list() | flex,
-                                 separator(),
-                                 render_status_bar(),
-                             }));
+        bool show_status = !status_message_.empty() || !error_message_.empty();
+
+        Elements layout;
+        layout.push_back(filter_line);
+        layout.push_back(separator());
+        layout.push_back(render_service_list() | flex);
+        if (show_status)
+        {
+            layout.push_back(separator());
+            layout.push_back(render_status_bar());
+        }
+
+        return window(title, vbox(std::move(layout)));
     }
 
     Element App::render_service_list()
@@ -236,11 +249,7 @@ namespace gsystemctl::ui
         {
             return text(error_message_) | color(Colors::error_fg());
         }
-        return hbox({
-            text(status_message_) | dim,
-            filler(),
-            text("q:quit r:refresh Enter:toggle l:logs") | dim,
-        });
+        return text(status_message_) | dim;
     }
 
     Element App::render_help()

--- a/src/ui/app.cpp
+++ b/src/ui/app.cpp
@@ -10,8 +10,9 @@ using namespace ftxui;
 namespace gsystemctl::ui
 {
 
-    App::App(bool system_mode) : screen_(ScreenInteractive::Fullscreen()), system_mode_(system_mode)
+    App::App(bool system_mode, const std::string &initial_filter) : screen_(ScreenInteractive::Fullscreen()), system_mode_(system_mode)
     {
+        filter_text_ = initial_filter;
         auto executor = std::make_shared<SystemCommandExecutor>();
         service_manager_ = ServiceManager::create(executor, system_mode_);
         logging_manager_ = LoggingManager::create(executor);

--- a/src/ui/app.cpp
+++ b/src/ui/app.cpp
@@ -134,7 +134,7 @@ namespace gsystemctl::ui
 
         return CatchEvent(renderer, [this, input](Event event)
                           {
-        if (event == Event::Character('q') || event == Event::Escape) {
+        if (event == Event::Special("\x1bq") || event == Event::Escape) {
             screen_.Exit();
             return true;
         }
@@ -142,11 +142,11 @@ namespace gsystemctl::ui
             show_help_ = !show_help_;
             return true;
         }
-        if (event == Event::Character('r')) {
+        if (event == Event::Special("\x1br")) {
             refresh_services();
             return true;
         }
-        if (event == Event::ArrowUp || event == Event::Character('k')) {
+        if (event == Event::ArrowUp || event == Event::Special("\x1bk")) {
             if (selected_index_ > 0) {
                 selected_index_--;
             }
@@ -154,7 +154,7 @@ namespace gsystemctl::ui
             error_message_.clear();
             return true;
         }
-        if (event == Event::ArrowDown || event == Event::Character('j')) {
+        if (event == Event::ArrowDown || event == Event::Special("\x1bj")) {
             if (selected_index_ < static_cast<int>(filtered_services_.size()) - 1) {
                 selected_index_++;
             }
@@ -166,7 +166,7 @@ namespace gsystemctl::ui
             toggle_selected_service();
             return true;
         }
-        if (event == Event::Character('l')) {
+        if (event == Event::Special("\x1bl")) {
             open_logs_for_selected_service();
             return true;
         }
@@ -290,19 +290,19 @@ namespace gsystemctl::ui
                    separator(),
                    text(""),
                    text("Navigation:") | bold,
-                   text("  Up/k      - Move selection up"),
-                   text("  Down/j    - Move selection down"),
-                   text("  Enter     - Toggle selected service (start/stop)"),
+                   text("  Up / Alt+k   - Move selection up"),
+                   text("  Down / Alt+j - Move selection down"),
+                   text("  Enter        - Toggle selected service (start/stop)"),
                    text(""),
                    text("Actions:") | bold,
-                   text("  r         - Refresh service list"),
-                   text("  ?         - Toggle this help screen"),
-                   text("  l         - Open logs for selected unit (tmux only)"),
-                   text("  q/Esc     - Quit"),
+                   text("  Alt+r        - Refresh service list"),
+                   text("  ?            - Toggle this help screen"),
+                   text("  Alt+l        - Open logs for selected unit (tmux only)"),
+                   text("  Alt+q / Esc  - Quit"),
                    text(""),
                    text("Filtering:") | bold,
-                   text("  Type      - Filter services by name"),
-                   text("  Backspace - Delete last character"),
+                   text("  Type         - Filter services by name"),
+                   text("  Backspace    - Delete last character"),
                    text(""),
                    separator(),
                    text("Press ? to close") | dim | center,

--- a/src/ui/app.cpp
+++ b/src/ui/app.cpp
@@ -203,6 +203,20 @@ namespace gsystemctl::ui
                 return true;
             }
             if (mouse.button == Mouse::Left && mouse.motion == Mouse::Pressed) {
+                for (size_t i = 0; i < toggle_button_boxes_.size(); ++i) {
+                    if (toggle_button_boxes_[i].Contain(mouse.x, mouse.y)) {
+                        selected_index_ = static_cast<int>(i);
+                        toggle_selected_service();
+                        return true;
+                    }
+                }
+                for (size_t i = 0; i < log_button_boxes_.size(); ++i) {
+                    if (log_button_boxes_[i].Contain(mouse.x, mouse.y)) {
+                        selected_index_ = static_cast<int>(i);
+                        open_logs_for_selected_service();
+                        return true;
+                    }
+                }
                 for (size_t i = 0; i < item_boxes_.size(); ++i) {
                     if (item_boxes_[i].Contain(mouse.x, mouse.y)) {
                         selected_index_ = static_cast<int>(i);
@@ -257,12 +271,15 @@ namespace gsystemctl::ui
 
         Elements items;
         item_boxes_.resize(filtered_services_.size());
+        toggle_button_boxes_.resize(filtered_services_.size());
+        log_button_boxes_.resize(filtered_services_.size());
         for (size_t i = 0; i < filtered_services_.size(); ++i)
         {
             const auto &svc = filtered_services_[i];
             bool selected = (static_cast<int>(i) == selected_index_);
             auto card = service_card(svc.unit, svc.sub, svc.description,
-                                     svc.is_running(), selected);
+                                     svc.is_running(), selected,
+                                     toggle_button_boxes_[i], log_button_boxes_[i]);
             if (selected)
             {
                 card = card | focus;

--- a/src/ui/app.cpp
+++ b/src/ui/app.cpp
@@ -187,30 +187,23 @@ namespace gsystemctl::ui
             return render_help();
         }
 
-        auto header = hbox({
-            text("g-systemctl") | bold | color(Color::Cyan),
+        auto filter_line = hbox({
+            text("Filter: ") | dim,
+            text(filter_text_.empty() ? "(type to filter)" : filter_text_) |
+                (filter_text_.empty() ? dim : nothing),
             filler(),
-            text(system_mode_ ? "[SYSTEM] " : "[USER] ") | dim,
-            text("Press ? for help") | dim,
+            text(system_mode_ ? "[SYSTEM]" : "[USER]") | dim,
         });
 
-        auto filter_box = hbox({
-                              text("Filter: ") | dim,
-                              text(filter_text_.empty() ? "(type to filter)" : filter_text_) |
-                                  (filter_text_.empty() ? dim : nothing),
-                          }) |
-                          border;
+        auto title = text(" g-systemctl ") | bold | color(Color::Cyan) | align_right;
 
-        return vbox({
-                   header,
-                   separator(),
-                   filter_box,
-                   separator(),
-                   render_service_list() | flex,
-                   separator(),
-                   render_status_bar(),
-               }) |
-               border;
+        return window(title, vbox({
+                                 filter_line,
+                                 separator(),
+                                 render_service_list() | flex,
+                                 separator(),
+                                 render_status_bar(),
+                             }));
     }
 
     Element App::render_service_list()

--- a/src/ui/app.cpp
+++ b/src/ui/app.cpp
@@ -1,6 +1,7 @@
 #include "g-systemctl/ui/app.hpp"
 #include "g-systemctl/ui/styles.hpp"
 #include "g-systemctl/core/command_executor.hpp"
+#include "g-systemctl/core/logging_manager.hpp"
 #include <algorithm>
 #include <cctype>
 
@@ -11,6 +12,7 @@ namespace gsystemctl::ui {
 App::App(bool system_mode) : screen_(ScreenInteractive::Fullscreen()), system_mode_(system_mode) {
     auto executor = std::make_shared<SystemCommandExecutor>();
     service_manager_ = ServiceManager::create(executor, system_mode_);
+    logging_manager_ = LoggingManager::create(executor);
     refresh_services();
 }
 
@@ -76,6 +78,26 @@ void App::toggle_selected_service() {
     }
 }
 
+void App::open_logs_for_selected_service() {
+    if (filtered_services_.empty() || selected_index_ < 0 ||
+        selected_index_ >= static_cast<int>(filtered_services_.size())) {
+        return;
+    }
+
+    const auto& service = filtered_services_[selected_index_];
+    status_message_ = "Opening logs for " + service.unit + "...";
+    screen_.PostEvent(Event::Custom);
+
+    if (logging_manager_) {
+        auto [success, message] = logging_manager_->open_logs(service.unit);
+        if (!success) {
+            error_message_ = "Unable to open logs: " + message;
+        }
+    } else {
+        error_message_ = "No logging manager available";
+    }
+}
+
 Component App::create_main_component() {
     auto input = Input(&filter_text_, "Filter services...");
 
@@ -110,6 +132,10 @@ Component App::create_main_component() {
         }
         if (event == Event::Return) {
             toggle_selected_service();
+            return true;
+        }
+        if (event == Event::Character('l')) {
+            open_logs_for_selected_service();
             return true;
         }
         if (event.is_character()) {
@@ -178,7 +204,7 @@ Element App::render_status_bar() {
     return hbox({
         text(status_message_) | dim,
         filler(),
-        text("q:quit r:refresh Enter:toggle") | dim,
+        text("q:quit r:refresh Enter:toggle l:logs") | dim,
     });
 }
 
@@ -195,6 +221,7 @@ Element App::render_help() {
         text("Actions:") | bold,
         text("  r         - Refresh service list"),
         text("  ?         - Toggle this help screen"),
+        text("  l         - Open logs for selected unit (tmux only)"),
         text("  q/Esc     - Quit"),
         text(""),
         text("Filtering:") | bold,

--- a/src/ui/app.cpp
+++ b/src/ui/app.cpp
@@ -184,6 +184,35 @@ namespace gsystemctl::ui
             error_message_.clear();
             return true;
         }
+        if (event.is_mouse()) {
+            auto& mouse = event.mouse();
+            if (mouse.button == Mouse::WheelUp) {
+                if (selected_index_ > 0) {
+                    selected_index_--;
+                }
+                status_message_.clear();
+                error_message_.clear();
+                return true;
+            }
+            if (mouse.button == Mouse::WheelDown) {
+                if (selected_index_ < static_cast<int>(filtered_services_.size()) - 1) {
+                    selected_index_++;
+                }
+                status_message_.clear();
+                error_message_.clear();
+                return true;
+            }
+            if (mouse.button == Mouse::Left && mouse.motion == Mouse::Pressed) {
+                for (size_t i = 0; i < item_boxes_.size(); ++i) {
+                    if (item_boxes_[i].Contain(mouse.x, mouse.y)) {
+                        selected_index_ = static_cast<int>(i);
+                        status_message_.clear();
+                        error_message_.clear();
+                        return true;
+                    }
+                }
+            }
+        }
         return false; });
     }
 
@@ -227,6 +256,7 @@ namespace gsystemctl::ui
         }
 
         Elements items;
+        item_boxes_.resize(filtered_services_.size());
         for (size_t i = 0; i < filtered_services_.size(); ++i)
         {
             const auto &svc = filtered_services_[i];
@@ -237,6 +267,7 @@ namespace gsystemctl::ui
             {
                 card = card | focus;
             }
+            card = card | reflect(item_boxes_[i]);
             items.push_back(card);
         }
 

--- a/src/ui/app.cpp
+++ b/src/ui/app.cpp
@@ -7,105 +7,133 @@
 
 using namespace ftxui;
 
-namespace gsystemctl::ui {
+namespace gsystemctl::ui
+{
 
-App::App(bool system_mode) : screen_(ScreenInteractive::Fullscreen()), system_mode_(system_mode) {
-    auto executor = std::make_shared<SystemCommandExecutor>();
-    service_manager_ = ServiceManager::create(executor, system_mode_);
-    logging_manager_ = LoggingManager::create(executor);
-    refresh_services();
-}
-
-int App::run() {
-    auto component = create_main_component();
-    screen_.Loop(component);
-    return 0;
-}
-
-void App::refresh_services() {
-    try {
-        services_ = service_manager_->list_services();
-        error_message_.clear();
-        status_message_ = "Loaded " + std::to_string(services_.size()) + " services";
-        apply_filter();
-    } catch (const std::exception& e) {
-        error_message_ = std::string("Error: ") + e.what();
-        services_.clear();
-        filtered_services_.clear();
+    App::App(bool system_mode) : screen_(ScreenInteractive::Fullscreen()), system_mode_(system_mode)
+    {
+        auto executor = std::make_shared<SystemCommandExecutor>();
+        service_manager_ = ServiceManager::create(executor, system_mode_);
+        logging_manager_ = LoggingManager::create(executor);
+        refresh_services();
     }
-}
 
-void App::apply_filter() {
-    if (filter_text_.empty()) {
-        filtered_services_ = services_;
-    } else {
-        filtered_services_.clear();
-        std::string lower_filter = filter_text_;
-        std::transform(lower_filter.begin(), lower_filter.end(), lower_filter.begin(),
-                       [](unsigned char c) { return std::tolower(c); });
+    int App::run()
+    {
+        auto component = create_main_component();
+        screen_.Loop(component);
+        return 0;
+    }
 
-        for (const auto& svc : services_) {
-            std::string lower_unit = svc.unit;
-            std::transform(lower_unit.begin(), lower_unit.end(), lower_unit.begin(),
-                           [](unsigned char c) { return std::tolower(c); });
-            if (lower_unit.find(lower_filter) != std::string::npos) {
-                filtered_services_.push_back(svc);
+    void App::refresh_services()
+    {
+        try
+        {
+            services_ = service_manager_->list_services();
+            error_message_.clear();
+            status_message_ = "Loaded " + std::to_string(services_.size()) + " services";
+            apply_filter();
+        }
+        catch (const std::exception &e)
+        {
+            error_message_ = std::string("Error: ") + e.what();
+            services_.clear();
+            filtered_services_.clear();
+        }
+    }
+
+    void App::apply_filter()
+    {
+        if (filter_text_.empty())
+        {
+            filtered_services_ = services_;
+        }
+        else
+        {
+            filtered_services_.clear();
+            std::string lower_filter = filter_text_;
+            std::transform(lower_filter.begin(), lower_filter.end(), lower_filter.begin(),
+                           [](unsigned char c)
+                           { return std::tolower(c); });
+
+            for (const auto &svc : services_)
+            {
+                std::string lower_unit = svc.unit;
+                std::transform(lower_unit.begin(), lower_unit.end(), lower_unit.begin(),
+                               [](unsigned char c)
+                               { return std::tolower(c); });
+                if (lower_unit.find(lower_filter) != std::string::npos)
+                {
+                    filtered_services_.push_back(svc);
+                }
             }
         }
-    }
 
-    if (selected_index_ >= static_cast<int>(filtered_services_.size())) {
-        selected_index_ = std::max(0, static_cast<int>(filtered_services_.size()) - 1);
-    }
-}
-
-void App::toggle_selected_service() {
-    if (filtered_services_.empty() || selected_index_ < 0 ||
-        selected_index_ >= static_cast<int>(filtered_services_.size())) {
-        return;
-    }
-
-    const auto& service = filtered_services_[selected_index_];
-    status_message_ = "Toggling " + service.unit + "...";
-    screen_.PostEvent(Event::Custom);
-
-    auto [success, message] = service_manager_->toggle_service(service);
-    if (success) {
-        status_message_ = "Successfully toggled " + service.unit;
-        refresh_services();
-    } else {
-        error_message_ = "Failed to toggle " + service.unit + ": " + message;
-    }
-}
-
-void App::open_logs_for_selected_service() {
-    if (filtered_services_.empty() || selected_index_ < 0 ||
-        selected_index_ >= static_cast<int>(filtered_services_.size())) {
-        return;
-    }
-
-    const auto& service = filtered_services_[selected_index_];
-    status_message_ = "Opening logs for " + service.unit + "...";
-    screen_.PostEvent(Event::Custom);
-
-    if (logging_manager_) {
-        auto [success, message] = logging_manager_->open_logs(service.unit);
-        if (!success) {
-            error_message_ = "Unable to open logs: " + message;
+        if (selected_index_ >= static_cast<int>(filtered_services_.size()))
+        {
+            selected_index_ = std::max(0, static_cast<int>(filtered_services_.size()) - 1);
         }
-    } else {
-        error_message_ = "No logging manager available";
     }
-}
 
-Component App::create_main_component() {
-    auto input = Input(&filter_text_, "Filter services...");
+    void App::toggle_selected_service()
+    {
+        if (filtered_services_.empty() || selected_index_ < 0 ||
+            selected_index_ >= static_cast<int>(filtered_services_.size()))
+        {
+            return;
+        }
 
-    auto renderer = Renderer(input, [this, input] {
-        return render();
-    });
+        const auto &service = filtered_services_[selected_index_];
+        status_message_ = "Toggling " + service.unit + "...";
+        screen_.PostEvent(Event::Custom);
 
-    return CatchEvent(renderer, [this, input](Event event) {
+        auto [success, message] = service_manager_->toggle_service(service);
+        if (success)
+        {
+            status_message_ = "Successfully toggled " + service.unit;
+            refresh_services();
+        }
+        else
+        {
+            error_message_ = "Failed to toggle " + service.unit + ": " + message;
+        }
+    }
+
+    void App::open_logs_for_selected_service()
+    {
+        if (filtered_services_.empty() || selected_index_ < 0 ||
+            selected_index_ >= static_cast<int>(filtered_services_.size()))
+        {
+            return;
+        }
+
+        const auto &service = filtered_services_[selected_index_];
+        status_message_ = "Opening logs for " + service.unit + "...";
+        screen_.PostEvent(Event::Custom);
+
+        if (logging_manager_)
+        {
+            auto [success, message] = logging_manager_->open_logs(service.unit);
+            if (!success)
+            {
+                error_message_ = "Unable to open logs: " + message;
+            }
+        }
+        else
+        {
+            error_message_ = "No logging manager available";
+        }
+    }
+
+    Component App::create_main_component()
+    {
+        auto input = Input(&filter_text_, "Filter services...");
+
+        auto renderer = Renderer(input, [this, input]
+                                 { return render(); });
+
+        return CatchEvent(renderer, [this, input](Event event)
+                          {
         if (event == Event::Character('q') || event == Event::Escape) {
             screen_.Exit();
             return true;
@@ -148,89 +176,104 @@ Component App::create_main_component() {
             apply_filter();
             return true;
         }
-        return false;
-    });
-}
-
-Element App::render() {
-    if (show_help_) {
-        return render_help();
+        return false; });
     }
 
-    auto header = hbox({
-        text("g-systemctl") | bold | color(Color::Cyan),
-        filler(),
-        text(system_mode_ ? "[SYSTEM] " : "[USER] ") | dim,
-        text("Press ? for help") | dim,
-    });
+    Element App::render()
+    {
+        if (show_help_)
+        {
+            return render_help();
+        }
 
-    auto filter_box = hbox({
-        text("Filter: ") | dim,
-        text(filter_text_.empty() ? "(type to filter)" : filter_text_) |
-            (filter_text_.empty() ? dim : nothing),
-    }) | border;
+        auto header = hbox({
+            text("g-systemctl") | bold | color(Color::Cyan),
+            filler(),
+            text(system_mode_ ? "[SYSTEM] " : "[USER] ") | dim,
+            text("Press ? for help") | dim,
+        });
 
-    return vbox({
-        header,
-        separator(),
-        filter_box,
-        separator(),
-        render_service_list() | flex,
-        separator(),
-        render_status_bar(),
-    }) | border;
-}
+        auto filter_box = hbox({
+                              text("Filter: ") | dim,
+                              text(filter_text_.empty() ? "(type to filter)" : filter_text_) |
+                                  (filter_text_.empty() ? dim : nothing),
+                          }) |
+                          border;
 
-Element App::render_service_list() {
-    if (filtered_services_.empty()) {
-        return text("No services found") | center | dim;
+        return vbox({
+                   header,
+                   separator(),
+                   filter_box,
+                   separator(),
+                   render_service_list() | flex,
+                   separator(),
+                   render_status_bar(),
+               }) |
+               border;
     }
 
-    Elements items;
-    for (size_t i = 0; i < filtered_services_.size(); ++i) {
-        const auto& svc = filtered_services_[i];
-        bool selected = (static_cast<int>(i) == selected_index_);
-        items.push_back(service_card(svc.unit, svc.sub, svc.description,
-                                     svc.is_running(), selected));
+    Element App::render_service_list()
+    {
+        if (filtered_services_.empty())
+        {
+            return text("No services found") | center | dim;
+        }
+
+        Elements items;
+        for (size_t i = 0; i < filtered_services_.size(); ++i)
+        {
+            const auto &svc = filtered_services_[i];
+            bool selected = (static_cast<int>(i) == selected_index_);
+            auto card = service_card(svc.unit, svc.sub, svc.description,
+                                     svc.is_running(), selected);
+            if (selected)
+            {
+                card = card | focus;
+            }
+            items.push_back(card);
+        }
+
+        return vbox(items) | vscroll_indicator | frame | flex;
     }
 
-    return vbox(items) | vscroll_indicator | frame | flex;
-}
-
-Element App::render_status_bar() {
-    if (!error_message_.empty()) {
-        return text(error_message_) | color(Colors::error_fg());
+    Element App::render_status_bar()
+    {
+        if (!error_message_.empty())
+        {
+            return text(error_message_) | color(Colors::error_fg());
+        }
+        return hbox({
+            text(status_message_) | dim,
+            filler(),
+            text("q:quit r:refresh Enter:toggle l:logs") | dim,
+        });
     }
-    return hbox({
-        text(status_message_) | dim,
-        filler(),
-        text("q:quit r:refresh Enter:toggle l:logs") | dim,
-    });
-}
 
-Element App::render_help() {
-    return vbox({
-        text("g-systemctl - Help") | bold | center,
-        separator(),
-        text(""),
-        text("Navigation:") | bold,
-        text("  Up/k      - Move selection up"),
-        text("  Down/j    - Move selection down"),
-        text("  Enter     - Toggle selected service (start/stop)"),
-        text(""),
-        text("Actions:") | bold,
-        text("  r         - Refresh service list"),
-        text("  ?         - Toggle this help screen"),
-        text("  l         - Open logs for selected unit (tmux only)"),
-        text("  q/Esc     - Quit"),
-        text(""),
-        text("Filtering:") | bold,
-        text("  Type      - Filter services by name"),
-        text("  Backspace - Delete last character"),
-        text(""),
-        separator(),
-        text("Press ? to close") | dim | center,
-    }) | border | center;
-}
+    Element App::render_help()
+    {
+        return vbox({
+                   text("g-systemctl - Help") | bold | center,
+                   separator(),
+                   text(""),
+                   text("Navigation:") | bold,
+                   text("  Up/k      - Move selection up"),
+                   text("  Down/j    - Move selection down"),
+                   text("  Enter     - Toggle selected service (start/stop)"),
+                   text(""),
+                   text("Actions:") | bold,
+                   text("  r         - Refresh service list"),
+                   text("  ?         - Toggle this help screen"),
+                   text("  l         - Open logs for selected unit (tmux only)"),
+                   text("  q/Esc     - Quit"),
+                   text(""),
+                   text("Filtering:") | bold,
+                   text("  Type      - Filter services by name"),
+                   text("  Backspace - Delete last character"),
+                   text(""),
+                   separator(),
+                   text("Press ? to close") | dim | center,
+               }) |
+               border | center;
+    }
 
 } // namespace gsystemctl::ui

--- a/src/ui/styles.cpp
+++ b/src/ui/styles.cpp
@@ -13,19 +13,22 @@ namespace gsystemctl::ui
     Color Colors::error_fg() { return Color::Red; }
 
     Element service_card(const std::string &name, const std::string &status,
-                         const std::string &description, bool is_running, bool selected)
+                         const std::string &description, bool is_running, bool selected,
+                         Box &toggle_box, Box &log_box)
     {
         auto status_color = is_running ? Colors::running_fg() : Colors::stopped_fg();
         auto button_text = is_running ? "STOP" : "START";
         auto button_color = is_running ? Color::Red : Color::Green;
 
         auto status_element = text(status) | color(status_color);
-        auto button_element = text(" [" + std::string(button_text) + "] ") | color(button_color) | bold;
+        auto log_element = text(" [LOG] ") | color(Color::Cyan) | bold | reflect(log_box);
+        auto toggle_element = text(" [" + std::string(button_text) + "] ") | color(button_color) | bold | reflect(toggle_box);
 
         auto content = vbox({
             hbox({
                 text(name) | bold | flex,
-                button_element,
+                log_element,
+                toggle_element,
             }),
             hbox({
                 status_element,

--- a/src/ui/styles.cpp
+++ b/src/ui/styles.cpp
@@ -27,8 +27,8 @@ namespace gsystemctl::ui
         auto content = vbox({
             hbox({
                 text(name) | bold | flex,
-                log_element,
                 toggle_element,
+                log_element,
             }),
             hbox({
                 status_element,

--- a/src/ui/styles.cpp
+++ b/src/ui/styles.cpp
@@ -2,42 +2,45 @@
 
 using namespace ftxui;
 
-namespace gsystemctl::ui {
+namespace gsystemctl::ui
+{
 
-Color Colors::running_fg() { return Color::Green; }
-Color Colors::running_bg() { return Color::GreenLight; }
-Color Colors::stopped_fg() { return Color::GrayDark; }
-Color Colors::stopped_bg() { return Color::GrayLight; }
-Color Colors::selected_bg() { return Color::Blue; }
-Color Colors::error_fg() { return Color::Red; }
+    Color Colors::running_fg() { return Color::Green; }
+    Color Colors::running_bg() { return Color::GreenLight; }
+    Color Colors::stopped_fg() { return Color::GrayDark; }
+    Color Colors::stopped_bg() { return Color::GrayLight; }
+    Color Colors::selected_bg() { return Color::Blue; }
+    Color Colors::error_fg() { return Color::Red; }
 
-Element service_card(const std::string& name, const std::string& status,
-                     const std::string& description, bool is_running, bool selected) {
-    auto status_color = is_running ? Colors::running_fg() : Colors::stopped_fg();
-    auto button_text = is_running ? "STOP" : "START";
-    auto button_color = is_running ? Color::Red : Color::Green;
+    Element service_card(const std::string &name, const std::string &status,
+                         const std::string &description, bool is_running, bool selected)
+    {
+        auto status_color = is_running ? Colors::running_fg() : Colors::stopped_fg();
+        auto button_text = is_running ? "STOP" : "START";
+        auto button_color = is_running ? Color::Red : Color::Green;
 
-    auto status_element = text(status) | color(status_color);
-    auto button_element = text(" [" + std::string(button_text) + "] ") | color(button_color) | bold;
+        auto status_element = text(status) | color(status_color);
+        auto button_element = text(" [" + std::string(button_text) + "] ") | color(button_color) | bold;
 
-    auto content = vbox({
-        hbox({
-            text(name) | bold | flex,
-            button_element,
-        }),
-        hbox({
-            text("Status: ") | dim,
-            status_element,
-        }),
-        text(description) | dim,
-    });
+        auto content = vbox({
+            hbox({
+                text(name) | bold | flex,
+                button_element,
+            }),
+            hbox({
+                status_element,
+                text(" · ") | dim,
+                text(description) | dim | flex,
+            }),
+        });
 
-    auto card = content | border;
-    if (selected) {
-        card = card | inverted;
+        auto card = content | border;
+        if (selected)
+        {
+            card = card | inverted;
+        }
+
+        return card;
     }
-
-    return card;
-}
 
 } // namespace gsystemctl::ui

--- a/tests/core/logging_manager_test.cpp
+++ b/tests/core/logging_manager_test.cpp
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+#include <g-systemctl/core/logging_manager.hpp>
+#include <cstdlib>
+
+namespace gsystemctl {
+
+TEST(LoggingManagerTest, CreateReturnsNonNull) {
+    auto manager = LoggingManager::create(nullptr);
+    EXPECT_NE(manager, nullptr);
+}
+
+TEST(LoggingManagerTest, OpenLogsWithoutTmuxFails) {
+    // ensure TMUX is not set for the duration of the test
+    unsetenv("TMUX");
+    auto manager = LoggingManager::create(nullptr);
+    auto [success, message] = manager->open_logs("foo.service");
+    EXPECT_FALSE(success);
+    EXPECT_NE(message.find("tmux"), std::string::npos);
+}
+
+} // namespace gsystemctl


### PR DESCRIPTION
- Add journalctl support using tmux, see #18 
- Allow to set filter at startup
- Mouse scrolling + clicking on start/stop button
- More compact UI
- Require alt for commands, because typing into the filter box would by accident fire commands, e.g. j or k or l
- Add Log button, with shortcut alt+l